### PR TITLE
feature/15.0/date_quick_links

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
@@ -5,7 +5,7 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
     const Domain = require('web.Domain');
     const pyUtils = require('web.py_utils');
 
-    const { DEFAULT_INTERVAL, DEFAULT_PERIOD,
+    const { DEFAULT_INTERVAL, DEFAULT_PERIOD, OVERRIDE_FILTERS,
         getComparisonOptions, getIntervalOptions, getPeriodOptions,
         constructDateDomain, rankInterval, yearSelected } = require('web.searchUtils');
 
@@ -543,6 +543,24 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
                         optionId: option.defaultYearId,
                     });
                 }
+            }
+
+            // Override Date filters if an Override filter is applied.
+            if (OVERRIDE_FILTERS.includes(optionId)) {
+                this.state.query = this.state.query.filter(
+                    queryElem => queryElem.optionId === optionId || queryElem.optionId === undefined
+                );
+            } else if (
+            this.state.query.filter(
+                queryElem => queryElem.optionId !== undefined
+            ).some(
+                queryElem => OVERRIDE_FILTERS.includes(queryElem.optionId)
+            )
+            && filter.type === "filter") {
+            // Remove Override filters if another Date Filter is selected.
+                this.state.query = this.state.query.filter(
+                    queryElem => queryElem.optionId === undefined || !OVERRIDE_FILTERS.includes(queryElem.optionId)
+                );
             }
             if (filter.type === 'filter') {
                 this._checkComparisonStatus();

--- a/addons/web/static/src/legacy/js/control_panel/search_utils.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_utils.js
@@ -89,7 +89,7 @@ odoo.define('web.searchUtils', function (require) {
         selection: 'selection',
     };
     const DEFAULT_PERIOD = 'this_month';
-    const OVERRIDE_FILTERS = ["year_to_date", "month_to_date", "today", "yesterday", "last_month", "last_year"];
+    const OVERRIDE_FILTERS = ["year_to_date", "month_to_date", "today", "yesterday", "mw_last_month", "mw_last_year"];
     const QUARTERS = {
         1: { description: _lt("Q1"), coveredMonths: [0, 1, 2] },
         2: { description: _lt("Q2"), coveredMonths: [3, 4, 5] },
@@ -101,8 +101,8 @@ odoo.define('web.searchUtils', function (require) {
             id: 'this_month', groupNumber: 1, format: 'MMMM',
             addParam: {}, granularity: 'month',
         },
-        previous_month: {
-            id: 'previous_month', groupNumber: 1, format: 'MMMM',
+        last_month: {
+            id: 'last_month', groupNumber: 1, format: 'MMMM',
             addParam: { months: -1 }, granularity: 'month',
         },
         antepenultimate_month: {
@@ -133,8 +133,8 @@ odoo.define('web.searchUtils', function (require) {
             id: 'this_year', groupNumber: 2, format: 'YYYY',
             addParam: {}, granularity: 'year',
         },
-        previous_year: {
-            id: 'previous_year', groupNumber: 2, format: 'YYYY',
+        last_year: {
+            id: 'last_year', groupNumber: 2, format: 'YYYY',
             addParam: { years: -1 }, granularity: 'year',
         },
         antepenultimate_year: {
@@ -171,12 +171,12 @@ odoo.define('web.searchUtils', function (require) {
             id: 'yesterday', groupNumber: 3, description: _lt('Yesterday'),
             addParam: { days: -1 }, granularity: 'day',
         },
-        last_year: {
-            id: 'last_year', groupNumber: 3, description: _lt('Last Year'),
+        mw_last_year: {
+            id: 'mw_last_year', groupNumber: 3, description: _lt('Last Year'),
             addParam: { years: -1 }, granularity: 'year',
         },
-        last_month: {
-            id: 'last_month', groupNumber: 3, description: _lt('Last Month'),
+        mw_last_month: {
+            id: 'mw_last_month', groupNumber: 3, description: _lt('Last Month'),
             format:'MMMM', addParam: { months: -1 }, granularity: 'month',
         },
     };
@@ -596,7 +596,7 @@ odoo.define('web.searchUtils', function (require) {
      * @returns {boolean}
      */
     function yearSelected(selectedOptionIds) {
-        return selectedOptionIds.some(optionId => !!YEAR_OPTIONS[optionId] || optionId === "last_year");
+        return selectedOptionIds.some(optionId => !!YEAR_OPTIONS[optionId] || optionId === "mw_last_year");
     }
 
     return {

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -9,6 +9,7 @@ import { SearchArchParser } from "./search_arch_parser";
 import {
     constructDateDomain,
     DEFAULT_INTERVAL,
+    OVERRIDE_FILTERS,
     getComparisonOptions,
     getIntervalOptions,
     getPeriodOptions,
@@ -901,6 +902,18 @@ export class SearchModel extends EventBus {
                 const { defaultYearId } = this.optionGenerators.find((o) => o.id === generatorId);
                 this.query.push({ searchItemId, generatorId: defaultYearId });
             }
+        }
+        // Override Selected Options if an Override Filter is applied
+        if (OVERRIDE_FILTERS.includes(generatorId)) {
+            this.query = this.query.filter(
+                (queryElem) => queryElem.generatorId == generatorId
+            );
+        }
+        else if (this.query.some(queryElem => OVERRIDE_FILTERS.includes(queryElem.generatorId))) {
+            // Remove Override filters if another Date Filter is applied
+            this.query = this.query.filter(
+                (queryElem) => !OVERRIDE_FILTERS.includes(queryElem.generatorId)
+            );
         }
         this._checkComparisonStatus();
         this._notify();

--- a/addons/web/static/src/search/utils/dates.js
+++ b/addons/web/static/src/search/utils/dates.js
@@ -7,7 +7,7 @@ import { localization } from "@web/core/l10n/localization";
 
 export const DEFAULT_PERIOD = "this_month";
 
-export const OVERRIDE_FILTERS = ["year_to_date", "month_to_date", "today", "yesterday", "last_month", "last_year"]
+export const OVERRIDE_FILTERS = ["year_to_date", "month_to_date", "today", "yesterday", "mw_last_month", "mw_last_year"]
 
 export const QUARTERS = {
     1: { description: _lt("Q1"), coveredMonths: [1, 2, 3] },
@@ -24,8 +24,8 @@ export const MONTH_OPTIONS = {
         plusParam: {},
         granularity: "month",
     },
-    previous_month: {
-        id: "previous_month",
+    last_month: {
+        id: "last_month",
         groupNumber: 1,
         format: "MMMM",
         plusParam: { months: -1 },
@@ -79,8 +79,8 @@ export const YEAR_OPTIONS = {
         plusParam: {},
         granularity: "year",
     },
-    previous_year: {
-        id: "previous_year",
+    last_year: {
+        id: "last_year",
         groupNumber: 2,
         format: "yyyy",
         plusParam: { years: -1 },
@@ -104,7 +104,7 @@ export const OVERRIDE_OPTIONS = {
         id: 'year_to_date', groupNumber: 3, description: _lt('Year to Date'),
         plusParam: {}, granularity: 'year,day',
     },
-        today: {
+    today: {
         id: 'today', groupNumber: 3, description: _lt('Today'),
         plusParam: {}, granularity: "day",
     },
@@ -112,12 +112,12 @@ export const OVERRIDE_OPTIONS = {
         id: 'yesterday', groupNumber: 3, description: _lt('Yesterday'),
         plusParam: { days: -1 }, granularity: 'day',
     },
-    last_year: {
-        id: 'last_year', groupNumber: 3, description: _lt('Last Year'),
+    mw_last_year: {
+        id: 'mw_last_year', groupNumber: 3, description: _lt('Last Year'),
         plusParam: { years: -1 }, granularity: "year",
     },
-    last_month: {
-        id: 'last_month', groupNumber: 3, description: _lt('Last Month'),
+    mw_last_month: {
+        id: 'mw_last_month', groupNumber: 3, description: _lt('Last Month'),
         plusParam: { months: -1 }, granularity: "month",
     },
 };
@@ -520,5 +520,5 @@ export function sortPeriodOptions(options) {
  * Checks if a year id is among the given array of period option ids.
  */
 export function yearSelected(selectedOptionIds) {
-    return selectedOptionIds.some((optionId) => Object.keys(YEAR_OPTIONS).includes(optionId) || optionId === "last_year");
+    return selectedOptionIds.some((optionId) => Object.keys(YEAR_OPTIONS).includes(optionId) || optionId === "mw_last_year");
 }


### PR DESCRIPTION
**[Create date quick links [19849]](https://erp.bluestingray.com/web#id=19849&view_type=form&model=project.task&action=372&active_id=488&menu_id=263)**

* [BLUE-1][ADD] Additional Date Filter Options

This commit adds 4 additional options for Filtering by Date. These four options include:

- Today
- Yesterday
- Month to Date
- Year to Date

These filters can be selected on any Date field present in the Filter Drop Down menu.

---

**QA**: @ambientstl 

To Test:
1. Install an app that has a date for filtering - MRP (Scheduled Date)
2. Set one date in the future, and one date more than a month ago.
3. Select Year To Date
4. Date in the Future should not be shown
5. Deselect Year To Date, and select Month To Date
6. Date in the future should not be shown, as well as the date from more than a
   month ago.
7. Set the date from more than one month ago to yesterday
8. Select the Yesterday Filter
9. Only those with Yesterday's Date should be shown.
10. Select Today Filter
11. Only those with Today's Date should be shown.