### PR TITLE
[BLUE-2][UPD] Background open list records in new tab

### DIFF
--- a/addons/web/static/src/legacy/js/views/list/list_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_renderer.js
@@ -996,7 +996,7 @@ var ListRenderer = BasicRenderer.extend({
 
                 switch(ev.originalEvent.which) {
                     case 1:
-                        if (ev.ctrlKey && baseURI.substring(baseURI.length - 4) === "list") {
+                        if (ev.ctrlKey || ev.metaKey && baseURI.substring(baseURI.length - 4) === "list") {
                             // Prevent record from being opened in current tab
                             ev.preventDefault();
                             // Construct form URL for selected record

--- a/addons/web/static/src/legacy/js/views/list/list_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_renderer.js
@@ -983,6 +983,46 @@ var ListRenderer = BasicRenderer.extend({
             $tr.addClass('o_list_no_open');
         }
         this._setDecorationClasses($tr, this.rowDecorations, record);
+        /**
+         * If the record is allowed to be opened and the current view is a list
+         * view (not a list embedded in a form view), add event listeners for
+         * Ctrl+Click and Middle Click to open the record in a new tab.
+         */
+        if (!$tr.hasClass('o_list_no_open')) {
+            $tr.mousedown(function(ev) {
+                var startURI;
+                var endURI;
+                var baseURI = $tr[0].baseURI;
+
+                switch(ev.originalEvent.which) {
+                    case 1:
+                        if (ev.ctrlKey && baseURI.substring(baseURI.length - 4) === "list") {
+                            // Prevent record from being opened in current tab
+                            ev.preventDefault();
+                            // Construct form URL for selected record
+                            [startURI, endURI] = baseURI.split("#");
+                            window.open(
+                                startURI + "#id=" + record.res_id + "&" +
+                                endURI.substring(0, endURI.length - 4) + "form",
+                                "_blank"
+                            );
+                        }
+                        break;
+                    case 2:
+                        if (baseURI.substring(baseURI.length - 4) === "list") {
+                            // Construct form URL for selected record
+                            [startURI, endURI] = baseURI.split("#");
+                            window.open(
+                                startURI + "#id=" + record.res_id + "&" +
+                                endURI.substring(0, endURI.length - 4) + "form",
+                                "_blank"
+                            );
+                        }
+                        break;
+                }
+                return true;
+            })
+        }
         return $tr;
     },
     /**


### PR DESCRIPTION
[Background open page in new tab [19850]](https://erp.bluestingray.com/web#id=19850&view_type=form&model=project.task&action=378&menu_id=263)

Adds event listeners to list records so Middle Click and Ctrl + Click open the record in a new tab.

To test:
 - Open any list view
 - Use middle click (click using the scroll button on the mouse) or Ctrl + Click (or Command + Click on Mac) to open the record in a new tab
 - Regular left click should still open the record in the current tab/window
 - If the User cannot open the record normally (`readonly` list views), middle click and Ctrl +Click should not open the record in a new tab (I don't know any default `readonly` list views off the top of my head)
 
QA: @Jessica-BlueStingray 